### PR TITLE
Fix sign in EV calculation and result

### DIFF
--- a/notebooks/ergodicity-explorations.ipynb
+++ b/notebooks/ergodicity-explorations.ipynb
@@ -94,7 +94,7 @@
    "source": [
     "We see that the expected value of the game is\n",
     "\n",
-    "$$\\mathbb{E}(x(t + \\Delta t)) = 0.5 \\cdot 1.6 x(t) - 0.5 \\cdot 0.5 x(t) = 0.55 x(t)$$\n",
+    "$$\\mathbb{E}(x(t + \\Delta t)) = 0.5 \\cdot 1.6 x(t) + 0.5 \\cdot 0.5 x(t) = 1.05 x(t)$$\n",
     "\n",
     "This makes it a positive **EV** game."
    ]


### PR DESCRIPTION
There should be no minus sign in the expected value calculation of the game.  

To view the change:
https://nbviewer.jupyter.org/github/lambdaclass/finance_playground/blob/244ef5166e2dacd3f053a3e1b89ad4f47c8e976a/notebooks/ergodicity-explorations.ipynb