### PR TITLE
Fix broken Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ branches:
 
 deploy:
   provider: pages
+  edge: true # use latest dpl release
   skip_cleanup: true
   github_token: $GITHUB_TOKEN # Set in travis-ci.org dashboard
   local_dir: html


### PR DESCRIPTION
Travis [dpl](https://github.com/travis-ci/dpl) v1.9.0 is broken for Github Pages.
See https://github.com/travis-ci/travis-ci/issues/9312

Switched to latest release.